### PR TITLE
feat: dockerize backend and frontend for production deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+node_modules
+dist
+lib
+generated
+.git
+.gitignore
+.husky
+.vscode
+.idea
+*.log
+*.md
+dev-container
+coverage
+.eslintcache
+.env
+.env.*

--- a/.env.production.example
+++ b/.env.production.example
@@ -1,0 +1,20 @@
+# PostgreSQL
+POSTGRES_USER=inland
+POSTGRES_PASSWORD=change-me-in-production
+POSTGRES_DB=inland
+
+# Secrets
+JWT_SECRET=change-me-in-production
+SESSION_SECRET=change-me-in-production
+
+# GitHub OAuth
+GITHUB_CLIENT_ID=your-github-client-id
+GITHUB_CLIENT_SECRET=your-github-client-secret
+
+# URLs (adjust to your domain)
+AUTH_CALLBACK_URL=https://your-domain.com/api/auth/github/callback
+APP_URL=https://your-domain.com
+API_URL=https://your-domain.com/api
+
+# Host port (default: 80)
+PORT=80

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,8 @@ Thumbs.db
 
 # env
 .env
+.env.*
+!.env.*.example
 *.env.local
 *.local.env
 .history

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,78 @@
+name: inland
+
+# Usage: cp .env.production.example .env.production && docker compose up -d
+env_file: .env.production
+
+services:
+  postgres:
+    image: postgres:18-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-inland}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB:-inland}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-inland}']
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:8-alpine
+    restart: unless-stopped
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  # No ports exposed — all external traffic goes through the frontend
+  # nginx reverse proxy (/api/ -> backend:3001)
+  backend:
+    build:
+      context: .
+      dockerfile: packages/backend/Dockerfile
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-inland}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-inland}
+      REDIS_URL: redis://redis:6379
+      NODE_ENV: production
+      JWT_SECRET: ${JWT_SECRET:?Set JWT_SECRET}
+      SESSION_SECRET: ${SESSION_SECRET:?Set SESSION_SECRET}
+      GITHUB_CLIENT_ID: ${GITHUB_CLIENT_ID:?Set GITHUB_CLIENT_ID}
+      GITHUB_CLIENT_SECRET: ${GITHUB_CLIENT_SECRET:?Set GITHUB_CLIENT_SECRET}
+      AUTH_CALLBACK_URL: ${AUTH_CALLBACK_URL:?Set AUTH_CALLBACK_URL}
+      APP_URL: ${APP_URL:?Set APP_URL}
+      API_URL: ${API_URL:?Set API_URL}
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://localhost:3001/health || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+
+  frontend:
+    build:
+      context: .
+      dockerfile: packages/frontend/Dockerfile
+    restart: unless-stopped
+    depends_on:
+      backend:
+        condition: service_healthy
+    ports:
+      - '${PORT:-80}:80'
+
+volumes:
+  postgres_data:
+    driver: local
+  redis_data:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 name: inland
 
-# Usage: cp .env.production.example .env.production && docker compose up -d
-env_file: .env.production
+# Usage:
+#   cp .env.production.example .env.production
+#   docker compose --env-file .env.production up -d
 
 services:
   postgres:
@@ -54,7 +55,7 @@ services:
       APP_URL: ${APP_URL:?Set APP_URL}
       API_URL: ${API_URL:?Set API_URL}
     healthcheck:
-      test: ['CMD-SHELL', 'wget -qO- http://localhost:3001/health || exit 1']
+      test: ['CMD-SHELL', 'wget -qO- http://127.0.0.1:3001/health || exit 1']
       interval: 10s
       timeout: 5s
       retries: 5

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -8,7 +8,7 @@ FROM base AS deps
 COPY package.json yarn.lock .yarnrc.yml ./
 COPY packages/backend/package.json packages/backend/
 COPY packages/dev/package.json packages/dev/
-RUN yarn workspaces focus @inland/backend --production=false
+RUN yarn workspaces focus @inland/backend
 
 # ---- Build ----
 FROM deps AS build
@@ -32,10 +32,10 @@ RUN apk add --no-cache tini
 WORKDIR /app
 
 COPY --from=prod-deps /app/node_modules ./node_modules
-COPY --from=prod-deps /app/packages/backend/node_modules ./packages/backend/node_modules
 COPY --from=build /app/packages/backend/dist ./packages/backend/dist
 COPY --from=build /app/packages/backend/generated ./packages/backend/generated
 COPY --from=build /app/packages/backend/prisma ./packages/backend/prisma
+COPY --from=build /app/packages/backend/prisma.config.ts ./packages/backend/
 COPY packages/backend/package.json ./packages/backend/
 COPY package.json ./
 

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -1,0 +1,49 @@
+# ---- Base ----
+FROM node:24-alpine AS base
+RUN corepack enable && corepack prepare yarn@4.13.0 --activate
+WORKDIR /app
+
+# ---- Dependencies ----
+FROM base AS deps
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY packages/backend/package.json packages/backend/
+COPY packages/dev/package.json packages/dev/
+RUN yarn workspaces focus @inland/backend --production=false
+
+# ---- Build ----
+FROM deps AS build
+COPY packages/backend/ packages/backend/
+COPY packages/dev/ packages/dev/
+COPY tsconfig.json ./
+RUN yarn workspace @inland/backend db:generate \
+ && yarn workspace @inland/backend build
+
+# ---- Production deps ----
+FROM base AS prod-deps
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY packages/backend/package.json packages/backend/
+COPY packages/dev/package.json packages/dev/
+RUN yarn workspaces focus @inland/backend --production
+
+# ---- Runtime ----
+FROM node:24-alpine AS runtime
+RUN corepack enable && corepack prepare yarn@4.13.0 --activate
+RUN apk add --no-cache tini
+WORKDIR /app
+
+COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=prod-deps /app/packages/backend/node_modules ./packages/backend/node_modules
+COPY --from=build /app/packages/backend/dist ./packages/backend/dist
+COPY --from=build /app/packages/backend/generated ./packages/backend/generated
+COPY --from=build /app/packages/backend/prisma ./packages/backend/prisma
+COPY packages/backend/package.json ./packages/backend/
+COPY package.json ./
+
+COPY packages/backend/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+ENV NODE_ENV=production
+EXPOSE 3001
+
+ENTRYPOINT ["tini", "--"]
+CMD ["/docker-entrypoint.sh"]

--- a/packages/backend/docker-entrypoint.sh
+++ b/packages/backend/docker-entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+cd /app/packages/backend
+npx prisma migrate deploy
+
+echo "Starting backend server..."
+exec node dist/main.js

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -1,0 +1,24 @@
+# ---- Base ----
+FROM node:24-alpine AS base
+RUN corepack enable && corepack prepare yarn@4.13.0 --activate
+WORKDIR /app
+
+# ---- Dependencies ----
+FROM base AS deps
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY packages/frontend/package.json packages/frontend/
+COPY packages/dev/package.json packages/dev/
+RUN yarn workspaces focus @inland/frontend --production=false
+
+# ---- Build ----
+FROM deps AS build
+COPY packages/frontend/ packages/frontend/
+COPY packages/dev/ packages/dev/
+COPY tsconfig.json ./
+RUN yarn workspace @inland/frontend build
+
+# ---- Runtime ----
+FROM nginx:alpine AS runtime
+COPY --from=build /app/packages/frontend/dist /usr/share/nginx/html
+COPY packages/frontend/nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -8,7 +8,7 @@ FROM base AS deps
 COPY package.json yarn.lock .yarnrc.yml ./
 COPY packages/frontend/package.json packages/frontend/
 COPY packages/dev/package.json packages/dev/
-RUN yarn workspaces focus @inland/frontend --production=false
+RUN yarn workspaces focus @inland/frontend
 
 # ---- Build ----
 FROM deps AS build

--- a/packages/frontend/nginx.conf
+++ b/packages/frontend/nginx.conf
@@ -1,0 +1,31 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # gzip
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript image/svg+xml;
+    gzip_min_length 256;
+
+    # API proxy
+    location /api/ {
+        proxy_pass http://backend:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Static assets with long cache
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- Add multi-stage Dockerfiles for `@inland/backend` and `@inland/frontend`, plus a top-level `docker-compose.yml` stack (postgres, redis, backend, frontend)
- Frontend container serves the SPA via nginx and reverse-proxies `/api/` to the backend; backend runs Prisma `migrate deploy` on boot via `docker-entrypoint.sh` and is fronted by tini
- `.env.production.example` + `.dockerignore` round out a `cp .env.production.example .env.production && docker compose --env-file .env.production up -d` workflow
- HTTPS termination is intentionally out of scope — self-host users on a LAN don't need it; public deploys should sit behind an external reverse proxy (Caddy/Traefik/nginx)

## Smoke-tested locally
- [x] `docker compose --env-file .env.production build` — both images build cleanly
- [x] `docker compose --env-file .env.production up -d` — all 4 containers reach healthy in order (postgres/redis → backend → frontend)
- [x] `curl http://localhost/api/auth/github` → `302` to GitHub OAuth with the correct callback URL and `client_id` injected from env
- [x] Prisma `migrate deploy` applies the init migration on a fresh database via the entrypoint
- [x] Static assets served with `Cache-Control: max-age=31536000`, HTML served with `Content-Encoding: gzip`, CORS `Access-Control-Allow-Origin` matches `APP_URL`

## Issues caught & fixed during smoke test
- `yarn workspaces focus --production=false` is invalid Yarn 4 syntax — `--production` is a boolean flag, dropped the `=false`
- Per-package `node_modules` `COPY` failed because Yarn 4 hoists everything to root
- `prisma migrate deploy` needs `prisma.config.ts` at runtime (Prisma 7 reads `DATABASE_URL` from it) — added the COPY
- Healthcheck used `localhost`, which Alpine resolves to IPv6 `::1`; the Fastify server binds IPv4 only — switched to `127.0.0.1`
- Top-level `env_file:` doesn't drive `${VAR}` interpolation in the compose file itself — replaced with a usage comment pointing at `--env-file`
- `.gitignore` didn't cover `.env.production` — added `.env.*` with a `!.env.*.example` exception

## Test plan
- [ ] Re-run the smoke test on a clean machine (fresh clone, no cached Docker layers)
- [ ] Walk a real GitHub OAuth login end-to-end against a deployed stack