### PR TITLE
docs: clone-free install via GHCR, split README and CONTRIBUTING

### DIFF
--- a/.env.production.example
+++ b/.env.production.example
@@ -18,3 +18,7 @@ API_URL=https://your-domain.com/api
 
 # Host port (default: 80)
 PORT=80
+
+# Image tag to pull from GHCR. Use `latest` to track main, or pin to a
+# specific release (e.g. 1.2.3) or commit (sha-abc1234).
+INLAND_TAG=latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,8 +97,9 @@ scripts/        repo scripts (codegen, init-db.sql)
 
 Production images are built and pushed by `.github/workflows/docker.yml` on every push to `main` and on `v*` git tags. See `packages/backend/Dockerfile` and `packages/frontend/Dockerfile`.
 
-To build locally:
+`docker-compose.yml` pulls images from GHCR by default. To build from local source instead (e.g. to test a change before pushing), overlay `docker-compose.build.yml`:
 
 ```bash
-docker compose --env-file .env.production build
+docker compose -f docker-compose.yml -f docker-compose.build.yml \
+  --env-file .env.production up -d --build
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,9 +97,15 @@ scripts/        repo scripts (codegen, init-db.sql)
 
 Production images are built and pushed by `.github/workflows/docker.yml` on every push to `main` and on `v*` git tags. See `packages/backend/Dockerfile` and `packages/frontend/Dockerfile`.
 
-`docker-compose.yml` pulls images from GHCR by default. To build from local source instead (e.g. to test a change before pushing), overlay `docker-compose.build.yml`:
+`docker-compose.yml` pulls images from GHCR by default. To smoke-test the production stack against local source, use the build overlay via `yarn docker:build`:
 
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.build.yml \
-  --env-file .env.production up -d --build
+cp .env.production.example .env.production   # fill in secrets + OAuth creds
+
+yarn docker:build   # build from source and start
+yarn docker:up      # start using GHCR images
+yarn docker:logs    # tail logs
+yarn docker:down    # stop the stack
 ```
+
+The build overlay (`docker-compose.build.yml`) layers `build:` directives on top of the base compose file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+# Contributing
+
+Thanks for your interest in working on Inland.
+
+## Tech stack
+
+- **Backend** (`packages/backend`) — Fastify 5, Effect-TS service layers, Prisma 7 (PostgreSQL), Redis sessions, GitHub OAuth
+- **Frontend** (`packages/frontend`) — React 19, Vite 8, Tailwind CSS 4, shadcn/ui, Effect-TS services, RxJS state management
+- **Dev tooling** (`packages/dev`) — internal tsconfig codegen, workspace utilities
+- **Monorepo** — Yarn 4 workspaces; Node version pinned in `.nvmrc`
+
+## Prerequisites
+
+- Node.js (see `.nvmrc`) — `nvm use` or equivalent
+- Docker + Docker Compose
+- A GitHub OAuth App pointed at `http://localhost:3001/api/auth/github/callback` (for local sign-in)
+
+## Setup
+
+```bash
+# 1. Start PostgreSQL + Redis for development
+docker compose -f dev-container/docker-compose.yml up -d
+
+# 2. Configure backend env
+cp packages/backend/.env.example packages/backend/.env
+# Edit packages/backend/.env: fill in GITHUB_CLIENT_ID / GITHUB_CLIENT_SECRET
+
+# 3. Install dependencies
+yarn install
+
+# 4. Apply database migrations
+yarn workspace @inland/backend db:migrate
+
+# 5. Run dev servers (in two terminals)
+yarn dev:fe   # frontend on http://localhost:3000
+yarn dev:be   # backend  on http://localhost:3001
+```
+
+The frontend dev server proxies `/api/*` to the backend on `:3001`.
+
+## Common commands
+
+```bash
+yarn tsc              # project-wide type check (uses TypeScript project references)
+yarn lint:ox          # oxlint
+yarn lint:eslint      # ESLint
+yarn lint:fmt         # oxfmt check
+yarn lint:fmt:fix     # oxfmt fix
+yarn test             # vitest watch
+yarn test:run         # vitest single run
+yarn test:coverage    # vitest with coverage
+yarn codegen          # regenerate tsconfig references across the monorepo
+```
+
+Pre-commit hooks (Husky + lint-staged) run oxfmt + ESLint fix on staged files and oxlint over the whole repo.
+
+## Architecture
+
+See [`CLAUDE.md`](./CLAUDE.md) for the canonical reference. The short version:
+
+- **Backend** uses Effect-TS for DI and error handling. Business logic lives in `services/`, data access in `repositories/`, external integrations in `providers/`. Routes use a `runRouteEffect()` helper that bridges Effect errors to HTTP responses.
+- **Frontend** uses Effect services backed by `BehaviorSubject` models for state. React components subscribe via a `useObservable()` hook. Side effects (data fetching, auto-selection) belong in the service layer, not in `useEffect`.
+
+`CLAUDE.md` also documents Effect-TS rules (error handling, type safety, layer construction, etc.) and project-wide code style. Please read it before opening a PR — review will check against these rules.
+
+## Testing
+
+```bash
+yarn test:run
+```
+
+- **Backend** tests live in `packages/backend/src/__test__/`. They use `vitest-mock-extended` for Prisma mocks and compose a `TestRepositoryLayer` to inject test doubles into the Effect runtime.
+- **Frontend** has no tests yet. When adding them, create `packages/frontend/vitest.config.ts` — the root config will auto-discover it. Mirror the backend pattern: mock dependencies in a test layer, run effects via `testRuntime.runPromise()`.
+
+## Commit & PR conventions
+
+- **Conventional Commits** are enforced via commitlint. Examples:
+  - `feat: add article editor toolbar`
+  - `fix(backend): handle expired session token`
+  - `chore: bump dependencies`
+  - `docs: clarify deployment steps`
+- Keep PRs focused; one logical change per PR.
+- CI runs type check, lint (oxlint + ESLint + oxfmt), and tests. All must pass.
+
+## Project structure
+
+```
+packages/
+  backend/      Fastify API
+  frontend/     React SPA
+  dev/          internal tooling
+dev-container/  docker-compose for local Postgres + Redis
+scripts/        repo scripts (codegen, init-db.sql)
+```
+
+## Docker images
+
+Production images are built and pushed by `.github/workflows/docker.yml` on every push to `main` and on `v*` git tags. See `packages/backend/Dockerfile` and `packages/frontend/Dockerfile`.
+
+To build locally:
+
+```bash
+docker compose --env-file .env.production build
+```

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ cp .env.production.example .env.production
 
 Edit `.env.production` and fill in:
 
-| Variable                                 | Description                                                            |
-| ---------------------------------------- | ---------------------------------------------------------------------- |
-| `POSTGRES_PASSWORD`                      | Database password (any strong value)                                   |
-| `JWT_SECRET`, `SESSION_SECRET`           | Random secrets, ≥32 bytes each (`openssl rand -hex 32`)                |
-| `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` | From step 1                                                          |
-| `AUTH_CALLBACK_URL`, `APP_URL`, `API_URL` | Public URLs of your deployment                                        |
-| `PORT`                                   | Host port for the frontend (default `80`)                              |
+| Variable                                   | Description                                             |
+| ------------------------------------------ | ------------------------------------------------------- |
+| `POSTGRES_PASSWORD`                        | Database password (any strong value)                    |
+| `JWT_SECRET`, `SESSION_SECRET`             | Random secrets, ≥32 bytes each (`openssl rand -hex 32`) |
+| `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` | From step 1                                             |
+| `AUTH_CALLBACK_URL`, `APP_URL`, `API_URL`  | Public URLs of your deployment                          |
+| `PORT`                                     | Host port for the frontend (default `80`)               |
 
 ### 3. Run
 

--- a/README.md
+++ b/README.md
@@ -3,4 +3,82 @@
 > [!WARNING]
 > WIP
 
-Markdown based documentation management system. Connects to GitHub. Based on Milkdown
+Markdown-based documentation management system. Connects to GitHub. Based on Milkdown.
+
+## Quick start
+
+Inland ships as a Docker Compose stack. Pre-built images are published to GHCR:
+
+- `ghcr.io/saul-mirone/inland-backend`
+- `ghcr.io/saul-mirone/inland-frontend`
+
+Tags: `latest` (main), `main`, `sha-<short>`, and semver (`X.Y.Z`, `X.Y`) on `v*` git tags.
+
+### 1. Create a GitHub OAuth App
+
+Inland uses GitHub for authentication.
+
+1. Go to <https://github.com/settings/developers> → **OAuth Apps** → **New OAuth App**
+2. Set:
+   - **Homepage URL** — your Inland URL (e.g. `https://inland.example.com`)
+   - **Authorization callback URL** — `<homepage>/api/auth/github/callback`
+3. Generate a client secret. Keep the client ID and secret.
+
+### 2. Configure environment
+
+```bash
+cp .env.production.example .env.production
+```
+
+Edit `.env.production` and fill in:
+
+| Variable                                 | Description                                                            |
+| ---------------------------------------- | ---------------------------------------------------------------------- |
+| `POSTGRES_PASSWORD`                      | Database password (any strong value)                                   |
+| `JWT_SECRET`, `SESSION_SECRET`           | Random secrets, ≥32 bytes each (`openssl rand -hex 32`)                |
+| `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` | From step 1                                                          |
+| `AUTH_CALLBACK_URL`, `APP_URL`, `API_URL` | Public URLs of your deployment                                        |
+| `PORT`                                   | Host port for the frontend (default `80`)                              |
+
+### 3. Run
+
+```bash
+docker compose --env-file .env.production up -d
+```
+
+This brings up PostgreSQL, Redis, the backend (runs database migrations on startup), and the frontend (nginx serving the SPA and reverse-proxying `/api/` to the backend).
+
+Check status:
+
+```bash
+docker compose ps
+docker compose logs -f
+```
+
+Open `http://localhost:${PORT}` (or your domain) and sign in with GitHub.
+
+## HTTPS
+
+The bundled `docker-compose.yml` serves plain HTTP. For any deployment exposed to the internet, put a TLS-terminating reverse proxy (Caddy, Traefik, or a cloud load balancer) in front of the frontend container and update `AUTH_CALLBACK_URL` / `APP_URL` / `API_URL` to `https://`.
+
+## Updating
+
+```bash
+docker compose --env-file .env.production pull
+docker compose --env-file .env.production up -d
+```
+
+Database migrations run automatically on backend startup.
+
+## Backup
+
+Persistent data lives in two named volumes: `inland_postgres_data` and `inland_redis_data`. Back up the PostgreSQL volume regularly:
+
+```bash
+docker compose --env-file .env.production exec postgres \
+  pg_dump -U "${POSTGRES_USER:-inland}" "${POSTGRES_DB:-inland}" > inland-$(date +%F).sql
+```
+
+## Contributing
+
+See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for development setup, architecture, and conventions.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Inland ships as a Docker Compose stack. Pre-built images are published to GHCR:
 
 Tags: `latest` (main), `main`, `sha-<short>`, and semver (`X.Y.Z`, `X.Y`) on `v*` git tags.
 
+You do **not** need to clone the repo — just two files (`docker-compose.yml` and `.env.production`) are enough.
+
 ### 1. Create a GitHub OAuth App
 
 Inland uses GitHub for authentication.
@@ -24,11 +26,21 @@ Inland uses GitHub for authentication.
    - **Authorization callback URL** — `<homepage>/api/auth/github/callback`
 3. Generate a client secret. Keep the client ID and secret.
 
-### 2. Configure environment
+### 2. Download the stack files
 
 ```bash
-cp .env.production.example .env.production
+mkdir inland && cd inland
+
+# docker-compose.yml — defines the services
+curl -fsSL -o docker-compose.yml \
+  https://raw.githubusercontent.com/Saul-Mirone/inland/main/docker-compose.yml
+
+# .env.production — environment variables (template)
+curl -fsSL -o .env.production \
+  https://raw.githubusercontent.com/Saul-Mirone/inland/main/.env.production.example
 ```
+
+### 3. Configure environment
 
 Edit `.env.production` and fill in:
 
@@ -39,14 +51,15 @@ Edit `.env.production` and fill in:
 | `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET` | From step 1                                             |
 | `AUTH_CALLBACK_URL`, `APP_URL`, `API_URL`  | Public URLs of your deployment                          |
 | `PORT`                                     | Host port for the frontend (default `80`)               |
+| `INLAND_TAG`                               | Image tag to deploy (`latest`, `X.Y.Z`, or `sha-...`)   |
 
-### 3. Run
+### 4. Run
 
 ```bash
 docker compose --env-file .env.production up -d
 ```
 
-This brings up PostgreSQL, Redis, the backend (runs database migrations on startup), and the frontend (nginx serving the SPA and reverse-proxying `/api/` to the backend).
+This pulls the GHCR images and brings up PostgreSQL, Redis, the backend (runs database migrations on startup), and the frontend (nginx serving the SPA and reverse-proxying `/api/` to the backend).
 
 Check status:
 

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,15 @@
+# Overlay for building images from source instead of pulling from GHCR.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.build.yml \
+#     --env-file .env.production up -d --build
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: packages/backend/Dockerfile
+
+  frontend:
+    build:
+      context: .
+      dockerfile: packages/frontend/Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,10 @@ name: inland
 # Usage:
 #   cp .env.production.example .env.production
 #   docker compose --env-file .env.production up -d
+#
+# Images are pulled from GHCR. To build locally instead (e.g. for
+# development), supply an override: docker compose -f docker-compose.yml
+# -f docker-compose.build.yml --env-file .env.production up -d --build
 
 services:
   postgres:
@@ -34,9 +38,7 @@ services:
   # No ports exposed — all external traffic goes through the frontend
   # nginx reverse proxy (/api/ -> backend:3001)
   backend:
-    build:
-      context: .
-      dockerfile: packages/backend/Dockerfile
+    image: ghcr.io/saul-mirone/inland-backend:${INLAND_TAG:-latest}
     restart: unless-stopped
     depends_on:
       postgres:
@@ -62,9 +64,7 @@ services:
       start_period: 15s
 
   frontend:
-    build:
-      context: .
-      dockerfile: packages/frontend/Dockerfile
+    image: ghcr.io/saul-mirone/inland-frontend:${INLAND_TAG:-latest}
     restart: unless-stopped
     depends_on:
       backend:

--- a/package.json
+++ b/package.json
@@ -21,7 +21,11 @@
     "test": "vitest",
     "test:run": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "test:ui": "vitest --ui"
+    "test:ui": "vitest --ui",
+    "docker:up": "docker compose --env-file .env.production up -d",
+    "docker:build": "docker compose -f docker-compose.yml -f docker-compose.build.yml --env-file .env.production up -d --build",
+    "docker:down": "docker compose --env-file .env.production down",
+    "docker:logs": "docker compose --env-file .env.production logs -f"
   },
   "dependencies": {
     "@commitlint/cli": "^21.0.0",


### PR DESCRIPTION
## Summary

- `docker-compose.yml` pulls images from GHCR by default — operators install Inland by `curl`-ing two files, no clone needed
- New `docker-compose.build.yml` overlay restores `build:` for repo developers who need to test local source
- `INLAND_TAG` env var lets operators pin to a specific image tag (`latest`, `X.Y.Z`, `sha-...`)
- `README.md` rewritten for operators: GHCR images, OAuth setup, env table, quick start, HTTPS note, updates, backups
- New `CONTRIBUTING.md` for contributors: local dev setup, commands, architecture pointers (links to `CLAUDE.md`), testing, conventional commits, build overlay

## Test plan

- [ ] `mkdir inland && cd inland && curl docker-compose.yml + .env.production.example` then `docker compose --env-file .env.production up -d` pulls GHCR images and starts the stack
- [ ] `docker compose -f docker-compose.yml -f docker-compose.build.yml --env-file .env.production up -d --build` still builds from source
- [ ] README + CONTRIBUTING render cleanly on the PR page
- [ ] Links resolve (`./CONTRIBUTING.md`, `./CLAUDE.md`, `./docker-compose.yml`)
